### PR TITLE
Make RTCPeerConnection.setRemoteDescription successCallback optional

### DIFF
--- a/lib/webrtc/ZombieRTCPeerConnection.js
+++ b/lib/webrtc/ZombieRTCPeerConnection.js
@@ -91,7 +91,9 @@ ZombieRTCPeerConnection.prototype.setRemoteDescription = function (description, 
 	}
 
 	this.remoteDescription = description;
-	process.nextTick(successCallback);
+	if (successCallback) {
+		process.nextTick(successCallback);
+	}
 	return Promise.resolve();
 };
 

--- a/test/webrtc/ZombieRTCPeerConnection_spec.js
+++ b/test/webrtc/ZombieRTCPeerConnection_spec.js
@@ -304,6 +304,32 @@ describe("A ZombieRTCPeerConnection", function () {
 				expect(connection.getRemoteStreams()[0]).to.be.an.instanceOf(ZombieRemoteStream);
 			});
 		});
+
+		describe("without a success callback", function () {
+			var connection  = new ZombieRTCPeerConnection();
+			var description = "description";
+			var result      = null;
+
+			before(function () {
+				result = connection.setRemoteDescription(description);
+			});
+
+			after(function () {
+				delete connection.remoteDescription;
+			});
+
+			it("sets the description", function () {
+				expect(connection.remoteDescription).to.equal(description);
+			});
+
+			it("returns a Promise that resolves", function () {
+				return result
+					.then(function () {
+						// This is hear to make sure a 'thenable' is returned
+						return;
+					});
+			});
+		});
 	});
 
 	describe("adding an ice candidate", function () {


### PR DESCRIPTION
Now that RTCPeerConnection.setRemoteDescription returns a Promise, the successCallback isn't needed for tracking success.  This makes the successCallback optional.

P.S. it's also the last PR I have right now to make jingle.js work against zombese in my testing! Thanks for the quick reviews and merging.