### PR TITLE
Allow initializing ZombieRemoteStreams with IDs and track lists

### DIFF
--- a/lib/webrtc/streams/ZombieMediaStream.js
+++ b/lib/webrtc/streams/ZombieMediaStream.js
@@ -1,8 +1,11 @@
 "use strict";
 var UUID = require("node-uuid");
+var _    = require("lodash");
 
-function ZombieMediaStream () {
-	this.id   = UUID.v4();
+function ZombieMediaStream (options) {
+	options      = options || {};
+	this.id      = options.id || UUID.v4();
+	this._tracks = options.tracks || [];
 }
 
 ZombieMediaStream.prototype.url = function () {
@@ -10,15 +13,15 @@ ZombieMediaStream.prototype.url = function () {
 };
 
 ZombieMediaStream.prototype.getAudioTracks = function () {
-	return [];
+	return _.filter(this._tracks, {kind: "audio"});
 };
 
 ZombieMediaStream.prototype.getVideoTracks = function () {
-	return [];
+	return _.filter(this._tracks, {kind: "video"});
 };
 
 ZombieMediaStream.prototype.getTracks = function () {
-	return [];
+	return _.clone(this._tracks);
 };
 
 module.exports = ZombieMediaStream;

--- a/lib/webrtc/streams/ZombieRemoteStream.js
+++ b/lib/webrtc/streams/ZombieRemoteStream.js
@@ -3,8 +3,8 @@ var URL = require("url");
 
 var ZombieMediaStream = require("./ZombieMediaStream");
 
-function ZombieRemoteStream () {
-	ZombieMediaStream.call(this);
+function ZombieRemoteStream (options) {
+	ZombieMediaStream.call(this, options);
 }
 
 ZombieRemoteStream.prototype             = Object.create(ZombieMediaStream.prototype);

--- a/test/webrtc/streams/ZombieMediaStream_spec.js
+++ b/test/webrtc/streams/ZombieMediaStream_spec.js
@@ -1,5 +1,6 @@
 "use strict";
 var expect            = require("chai").expect;
+var UUID              = require("node-uuid");
 var ZombieMediaStream = require("../../../lib/webrtc/streams/ZombieMediaStream");
 
 describe("A Zombie media stream", function () {
@@ -13,6 +14,49 @@ describe("A Zombie media stream", function () {
 		expect(stream, "id").to.have.property("id")
 		.that.is.a("string")
 		.and.has.length.greaterThan(0);
+	});
+
+	it("will accept an id option in the constructor arguments", function () {
+		var id = UUID.v4();
+		var testStream = new ZombieMediaStream({id: id});
+		expect(testStream.id).to.equal(id);
+	});
+
+	it("will default to having no tracks", function () {
+		expect(stream.getTracks()).to.have.length(0);
+	});
+
+	it("will initialize the tracks list from an optional constructor argument", function () {
+		var tracks = [
+			{kind: "audio"},
+			{kind: "video"}
+		];
+		var testStream = new ZombieMediaStream({tracks: tracks});
+		expect(testStream.getTracks()).to.deep.equal(tracks);
+	});
+
+	describe("audio track list", function () {
+		it("will include only tracks with kind=audio", function () {
+			var tracks = [
+				{kind: "data"},
+				{kind: "audio"},
+				{kind: "video"}
+			];
+			var testStream = new ZombieMediaStream({tracks: tracks});
+			expect(testStream.getAudioTracks()).to.deep.equal([{kind: "audio"}]);
+		});
+	});
+
+	describe("video track list", function () {
+		it("will include only tracks with kind=video", function () {
+			var tracks = [
+				{kind: "data"},
+				{kind: "audio"},
+				{kind: "video"}
+			];
+			var testStream = new ZombieMediaStream({tracks: tracks});
+			expect(testStream.getVideoTracks()).to.deep.equal([{kind: "video"}]);
+		});
 	});
 
 	describe("rendered as a string", function () {

--- a/test/webrtc/streams/ZombieRemoteStream_spec.js
+++ b/test/webrtc/streams/ZombieRemoteStream_spec.js
@@ -1,5 +1,6 @@
 "use strict";
 var expect             = require("chai").expect;
+var UUID               = require("node-uuid");
 var ZombieMediaStream  = require("../../../lib/webrtc/streams/ZombieMediaStream");
 var ZombieRemoteStream = require("../../../lib/webrtc/streams/ZombieRemoteStream");
 
@@ -14,12 +15,27 @@ describe("A zombese remote media stream", function () {
 		expect(stream, "stream").to.be.an.instanceOf(ZombieMediaStream);
 	});
 
-	it("has an empty audio track list", function () {
+	it("will accept an id option in the constructor arguments", function () {
+		var id = UUID.v4();
+		var testStream = new ZombieRemoteStream({id: id});
+		expect(testStream.id).to.equal(id);
+	});
+
+	it("will initialize the tracks list from an optional constructor argument", function () {
+		var tracks = [
+			{kind: "audio"},
+			{kind: "video"}
+		];
+		var testStream = new ZombieRemoteStream({tracks: tracks});
+		expect(testStream.getTracks()).to.deep.equal(tracks);
+	});
+
+	it("defaults to an empty audio track list", function () {
 		var audioTracks = stream.getAudioTracks();
 		expect(audioTracks, "audio tracks").to.deep.equal([]);
 	});
 
-	it("has an empty video track list", function () {
+	it("defaults to an empty video track list", function () {
 		var videoTracks = stream.getVideoTracks();
 		expect(videoTracks, "video tracks").to.deep.equal([]);
 	});


### PR DESCRIPTION
This is a precursor to other changes that I'm working on.  When building remote stream data structures, possibly from a remote description, it would be helpful to be able to pick the id and pre-populate the track list for the remote stream.

With SDP's SSRC support, the incoming remote description might describe stream idea and tracks to the PeerConnection, and this change would allow the PeerConnection to create remote streams that match the description. I'm working on a change that would respect the remote description track lists.