### PR TITLE
Initialize local streams from constraints

### DIFF
--- a/lib/webrtc/dialects/FirefoxZombeseDialect.js
+++ b/lib/webrtc/dialects/FirefoxZombeseDialect.js
@@ -23,7 +23,7 @@ FirefoxZombeseDialect.prototype.teach = function (window) {
 	window.MediaStreamTrack         = ZombieMediaStreamTrack;
 
 	navigator.mozGetUserMedia = function (constraints, successCallback) {
-		var stream = new ZombieLocalStream();
+		var stream = new ZombieLocalStream(constraints);
 
 		process.nextTick(successCallback.bind(null, stream));
 	};

--- a/lib/webrtc/streams/ZombieLocalStream.js
+++ b/lib/webrtc/streams/ZombieLocalStream.js
@@ -1,10 +1,23 @@
 "use strict";
 var URL = require("url");
 
-var ZombieMediaStream = require("./ZombieMediaStream");
+var ZombieMediaStream      = require("./ZombieMediaStream");
+var ZombieMediaStreamTrack = require("./ZombieMediaStreamTrack");
 
-function ZombieLocalStream () {
-	ZombieMediaStream.call(this);
+function ZombieLocalStream (constraints) {
+	constraints = constraints || {};
+	var tracks = [];
+	if (constraints.audio) {
+		var audioTrack = new ZombieMediaStreamTrack("audio");
+		tracks.push(audioTrack);
+	}
+
+	if (constraints.video) {
+		var videoTrack = new ZombieMediaStreamTrack("video");
+		tracks.push(videoTrack);
+	}
+
+	ZombieMediaStream.call(this, {tracks: tracks});
 }
 
 ZombieLocalStream.prototype             = Object.create(ZombieMediaStream.prototype);

--- a/lib/webrtc/streams/ZombieMediaStream.js
+++ b/lib/webrtc/streams/ZombieMediaStream.js
@@ -1,8 +1,11 @@
 "use strict";
 var UUID = require("node-uuid");
+var _    = require("lodash");
 
-function ZombieMediaStream () {
-	this.id   = UUID.v4();
+function ZombieMediaStream (options) {
+	options      = options || {};
+	this.id      = options.id || UUID.v4();
+	this._tracks = options.tracks || [];
 }
 
 ZombieMediaStream.prototype.url = function () {
@@ -10,15 +13,15 @@ ZombieMediaStream.prototype.url = function () {
 };
 
 ZombieMediaStream.prototype.getAudioTracks = function () {
-	return [];
+	return _.filter(this._tracks, {kind: "audio"});
 };
 
 ZombieMediaStream.prototype.getVideoTracks = function () {
-	return [];
+	return _.filter(this._tracks, {kind: "video"});
 };
 
 ZombieMediaStream.prototype.getTracks = function () {
-	return [];
+	return _.clone(this._tracks);
 };
 
 module.exports = ZombieMediaStream;

--- a/lib/webrtc/streams/ZombieMediaStreamTrack.js
+++ b/lib/webrtc/streams/ZombieMediaStreamTrack.js
@@ -1,8 +1,9 @@
 "use strict";
 var UUID = require("node-uuid");
 
-function ZombieMediaStreamTrack () {
+function ZombieMediaStreamTrack (kind) {
 	this.id      = UUID.v4();
+	this.kind    = kind || "audio";
 	this.enabled = true;
 	this.readyState = "live";
 }

--- a/lib/webrtc/streams/ZombieRemoteStream.js
+++ b/lib/webrtc/streams/ZombieRemoteStream.js
@@ -3,8 +3,8 @@ var URL = require("url");
 
 var ZombieMediaStream = require("./ZombieMediaStream");
 
-function ZombieRemoteStream () {
-	ZombieMediaStream.call(this);
+function ZombieRemoteStream (options) {
+	ZombieMediaStream.call(this, options);
 }
 
 ZombieRemoteStream.prototype             = Object.create(ZombieMediaStream.prototype);

--- a/test/webrtc/dialects/FirefoxZombeseDialect_spec.js
+++ b/test/webrtc/dialects/FirefoxZombeseDialect_spec.js
@@ -64,6 +64,24 @@ describe("The Firefox dialect", function () {
 				expect(success.calledOnce).to.be.true;
 				expect(success.calledWith(Sinon.match.instanceOf(ZombieLocalStream))).to.be.true;
 			});
+
+			describe("when constraints are provided", function () {
+				it("will create an audio track if an audio track constraint exists", function (done) {
+					window.navigator.mozGetUserMedia({audio: true}, function (stream) {
+						expect(stream.getAudioTracks(), "audio tracks").to.have.length(1);
+						expect(stream.getVideoTracks(), "video tracks").to.have.length(0);
+						done();
+					});
+				});
+
+				it("will create an video track if an video track constraint exists", function (done) {
+					window.navigator.mozGetUserMedia({video: true}, function (stream) {
+						expect(stream.getVideoTracks(), "video tracks").to.have.length(1);
+						expect(stream.getAudioTracks(), "audio tracks").to.have.length(0);
+						done();
+					});
+				});
+			});
 		});
 	});
 });

--- a/test/webrtc/streams/ZombieLocalStream_spec.js
+++ b/test/webrtc/streams/ZombieLocalStream_spec.js
@@ -14,19 +14,33 @@ describe("A zombese local media stream", function () {
 		expect(stream, "stream").to.be.an.instanceOf(ZombieMediaStream);
 	});
 
-	it("has an empty audio track list", function () {
+	it("defaults to an empty audio track list", function () {
 		var audioTracks = stream.getAudioTracks();
 		expect(audioTracks, "audio tracks").to.deep.equal([]);
 	});
 
-	it("has an empty video track list", function () {
+	it("defaults to an empty video track list", function () {
 		var videoTracks = stream.getVideoTracks();
 		expect(videoTracks, "video tracks").to.deep.equal([]);
 	});
 
-	it("has an empty track list", function () {
+	it("defaults to an empty track list", function () {
 		var tracks = stream.getTracks();
 		expect(tracks, "tracks").to.deep.equal([]);
+	});
+
+	describe("when constraints are provided", function () {
+		it("will create an audio track if an audio track constraint exists", function () {
+			var newStream = new ZombieLocalStream({audio: true});
+			expect(newStream.getAudioTracks(), "audio tracks").to.have.length(1);
+			expect(newStream.getVideoTracks(), "video tracks").to.have.length(0);
+		});
+
+		it("will create an video track if an video track constraint exists", function () {
+			var newStream = new ZombieLocalStream({video: true});
+			expect(newStream.getVideoTracks(), "video tracks").to.have.length(1);
+			expect(newStream.getAudioTracks(), "audio tracks").to.have.length(0);
+		});
 	});
 
 	describe("rendered as a string", function () {

--- a/test/webrtc/streams/ZombieMediaStream_spec.js
+++ b/test/webrtc/streams/ZombieMediaStream_spec.js
@@ -1,5 +1,6 @@
 "use strict";
 var expect            = require("chai").expect;
+var UUID              = require("node-uuid");
 var ZombieMediaStream = require("../../../lib/webrtc/streams/ZombieMediaStream");
 
 describe("A Zombie media stream", function () {
@@ -13,6 +14,49 @@ describe("A Zombie media stream", function () {
 		expect(stream, "id").to.have.property("id")
 		.that.is.a("string")
 		.and.has.length.greaterThan(0);
+	});
+
+	it("will accept an id option in the constructor arguments", function () {
+		var id = UUID.v4();
+		var testStream = new ZombieMediaStream({id: id});
+		expect(testStream.id).to.equal(id);
+	});
+
+	it("will default to having no tracks", function () {
+		expect(stream.getTracks()).to.have.length(0);
+	});
+
+	it("will initialize the tracks list from an optional constructor argument", function () {
+		var tracks = [
+			{kind: "audio"},
+			{kind: "video"}
+		];
+		var testStream = new ZombieMediaStream({tracks: tracks});
+		expect(testStream.getTracks()).to.deep.equal(tracks);
+	});
+
+	describe("audio track list", function () {
+		it("will include only tracks with kind=audio", function () {
+			var tracks = [
+				{kind: "data"},
+				{kind: "audio"},
+				{kind: "video"}
+			];
+			var testStream = new ZombieMediaStream({tracks: tracks});
+			expect(testStream.getAudioTracks()).to.deep.equal([{kind: "audio"}]);
+		});
+	});
+
+	describe("video track list", function () {
+		it("will include only tracks with kind=video", function () {
+			var tracks = [
+				{kind: "data"},
+				{kind: "audio"},
+				{kind: "video"}
+			];
+			var testStream = new ZombieMediaStream({tracks: tracks});
+			expect(testStream.getVideoTracks()).to.deep.equal([{kind: "video"}]);
+		});
 	});
 
 	describe("rendered as a string", function () {

--- a/test/webrtc/streams/ZombieRemoteStream_spec.js
+++ b/test/webrtc/streams/ZombieRemoteStream_spec.js
@@ -1,5 +1,6 @@
 "use strict";
 var expect             = require("chai").expect;
+var UUID               = require("node-uuid");
 var ZombieMediaStream  = require("../../../lib/webrtc/streams/ZombieMediaStream");
 var ZombieRemoteStream = require("../../../lib/webrtc/streams/ZombieRemoteStream");
 
@@ -14,12 +15,27 @@ describe("A zombese remote media stream", function () {
 		expect(stream, "stream").to.be.an.instanceOf(ZombieMediaStream);
 	});
 
-	it("has an empty audio track list", function () {
+	it("will accept an id option in the constructor arguments", function () {
+		var id = UUID.v4();
+		var testStream = new ZombieRemoteStream({id: id});
+		expect(testStream.id).to.equal(id);
+	});
+
+	it("will initialize the tracks list from an optional constructor argument", function () {
+		var tracks = [
+			{kind: "audio"},
+			{kind: "video"}
+		];
+		var testStream = new ZombieRemoteStream({tracks: tracks});
+		expect(testStream.getTracks()).to.deep.equal(tracks);
+	});
+
+	it("defaults to an empty audio track list", function () {
 		var audioTracks = stream.getAudioTracks();
 		expect(audioTracks, "audio tracks").to.deep.equal([]);
 	});
 
-	it("has an empty video track list", function () {
+	it("defaults to an empty video track list", function () {
 		var videoTracks = stream.getVideoTracks();
 		expect(videoTracks, "video tracks").to.deep.equal([]);
 	});


### PR DESCRIPTION
When `navigator.mozGetUserMedia()` is used to create a local stream, the local stream should be populated with audio and video tracks, depending on the constraints from the `navigator.mozGetUserMedia()` call.

NOTE:  This branch builds on PR #16 so it's easiest to review if that PR is merged first.  I've put this up so that while reviewing PR #16 it's possible to see some use of the newly added API.